### PR TITLE
Add proxy line into the default autofc2 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ Where the `autofc2.json` file looks like this:
     "cookies_file": null,
     "remux": true,
     "keep_intermediates": false,
-    "extract_audio": true
+    "extract_audio": true,
+    "trust_env_proxy": false
   },
   "channels": {
     "91544481": {


### PR DESCRIPTION
While it's not explicitly stated, autofc2 also supports the proxy setting. Therefore I'm proposing this PR to add it into the default config file example.