### PR TITLE
Handle TimeoutError in FC2WebSocket._main_loop

### DIFF
--- a/fc2_live_dl/fc2.py
+++ b/fc2_live_dl/fc2.py
@@ -83,9 +83,15 @@ class FC2WebSocket:
 
     async def _main_loop(self):
         while True:
-            msg = await asyncio.wait_for(
-                self._ws.receive_json(), self.heartbeat_interval
-            )
+            try:
+                msg = await asyncio.wait_for(
+                    self._ws.receive_json(), self.heartbeat_interval
+                )
+            except asyncio.TimeoutError:
+                self._logger.debug(f'Got no messages for {self.heartbeat_interval} seconds, sending heartbeat')
+                await self._try_heartbeat()
+                continue
+
             self._logger.trace("<", json.dumps(msg)[:100])
             if self._output_file is not None:
                 self._output_file.write("< ")


### PR DESCRIPTION
Fixing #31.

Hopefully I understood original intent correctly: `_try_heartbeat` gets called after every received message or if there was no messages for `heartbeat_interval`.
Downside of the way it is done is the use of two `_try_heartbeat` calls, but it seems to be the easiest way to avoid sending heartbeat in response to error/end of stream message, when `_main_loop` raises exception.

Is `debug` a fitting log level for message about timeout? I used it because `heartbeat` message itself is `debug`, but perhaps it should have been `trace`?